### PR TITLE
Bump actions/checkout to v7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: DeterminateSystems/nix-installer-action@main
       - run: nix develop --command pnpm install
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: DeterminateSystems/nix-installer-action@main
       - run: nix develop --command pnpm install
       - run: nix develop --command pnpm -s test


### PR DESCRIPTION
GitHub forces `checkout@v3`'s Node 20 runtime onto Node 24 and warns on every run. Bumps both the test and deploy workflows to `v7` (current latest) to clear it.